### PR TITLE
Document GitHub Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,15 @@ More information about the usage of this directory in [the documentation](https:
 This directory contains your Vuex store files. Creating a file in this directory automatically activates Vuex.
 
 More information about the usage of this directory in [the documentation](https://nuxtjs.org/docs/2.x/directory-structure/store).
+
+## Deployment on GitHub Pages
+
+This repository is named `Stonnee.github.io`, which means GitHub Pages serves the site from the **default branch**. After running `npm run generate`, commit the contents of `dist/` to that branch so `index.html` is located at the repository root.
+
+The `maj` script automates this process:
+
+```bash
+./maj
+```
+
+It generates the static site and pushes the updated `dist` directory to `master`.

--- a/maj
+++ b/maj
@@ -9,5 +9,5 @@ git add dist
 # Valide les changements
 git commit -m "Mettre à jour le contenu généré"
 
-# Pousse les changements vers la branche gh-pages
-git subtree push --prefix dist origin gh-pages
+# Pousse les changements vers la branche par défaut (master)
+git subtree push --prefix dist origin master


### PR DESCRIPTION
## Summary
- revert accidental commit of build artifacts
- describe how to deploy from the default branch
- update `maj` script to push `dist` to master

## Testing
- `npm run generate`


------
https://chatgpt.com/codex/tasks/task_e_684b3360c1688322933ede8aa0d859ad

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Document the process for deploying the site on GitHub Pages and update the deployment script to push changes to the default branch `master` instead of `gh-pages`.

### Why are these changes being made?

The repository is configured to serve the site from the default branch using GitHub Pages. Updating the documentation clarifies the deployment process, and modifying the script ensures changes are pushed to the appropriate branch, aligning the deployment strategy with GitHub Pages' requirements.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->